### PR TITLE
Chris/publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Run `pip install git+https://github.com/qrithm/paqr.git`
 
 Run:
 
-`python -m paqr.create . <your-paq-name>
+`python -m paqr.create . <your-paq-name>`
 
 to initialize a paq with your name from the starter-paq `https://github.com/qrithm/starter-paq`
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,7 @@ Helper library for packing ML apps to be published on Qrithm
 
 ## Installation
 
-Add `git+https://github.com/qrithm/paqr.git` to the requirements.txt file of your paq.
-
-In the future we may cut releases, but for now this is based off master.
-
-Install your requirements file so that `paqr` can be run from the shell
+Run `pip install git+https://github.com/qrithm/paqr.git`
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Helper library for packing ML apps to be published on Qrithm
 
 ## Installation
 
-Add `git+https://github.com/qrithm/paqr@master` to the requirements.txt file of your paq.
+Add `git+https://github.com/qrithm/paqr.git` to the requirements.txt file of your paq.
 
 In the future we may cut releases, but for now this is based off master.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ Add `git+https://github.com/qrithm/paqr@master` to the requirements.txt file of 
 
 In the future we may cut releases, but for now this is based off master.
 
+Install your requirements file so that `paqr` can be run from the shell
+
 ## Usage
+
+### Implement your predictor
 
 Implement your Predictor as follow:
 
@@ -22,4 +26,28 @@ Predictor(PredictorInterface):
     return output
 ```
 
-The paqr package includes a base set of requirements such as fastapi and uvicorn that are common to all apps, so you only need to include the requirements specific to your app in the requirements.txt file.
+### Implement your server
+
+Implement a FastAPI server that serves predictions from your Predictor at specified API endpoints.
+
+See https://github.com/qrithm/template/blob/master/server.py for an example
+
+### Add config files
+
+Add a `paq.yaml` file to your paq directory. You can copy the one in this directory and customize it to your needs
+
+Add a Dockerfile to your paq directory. It should containerize your paq and run your server. See
+
+https://github.com/qrithm/template/blob/master/Dockerfile for an example.
+
+TODO: Remove Dockerfile requirement, and automatically add a standard Dockerfile if one has not been added
+
+### (Optional) Run your paq
+
+You can run your paq with `python -m paqr.run <path-to-your-paq>`. Specify your own port if needed with `--port <your-port>`
+
+### Publish your paq
+
+Publish your paq with `python -m paqr.publish <path-to-your-paq>`. If your name is not available you may need to select a new name.
+
+If publishing is successful the host API URL should be printed out at the end of this process. You can check it out by visiting `<host-url>/docs`

--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ Install your requirements file so that `paqr` can be run from the shell
 
 ## Usage
 
+### Initialize your paq
+
+Run:
+
+`python -m paqr.create . <your-paq-name>
+
+to initialize a paq with your name from the starter-paq `https://github.com/qrithm/starter-paq`
+
 ### Implement your predictor
 
 Implement your Predictor as follow:

--- a/paq.yaml
+++ b/paq.yaml
@@ -1,3 +1,4 @@
 name: <sample-paq-name>
 memory: 2048M
 cpu: "1"
+concurrency: "80"

--- a/paq.yaml
+++ b/paq.yaml
@@ -1,0 +1,2 @@
+name: <sample-paq-name>
+memory: 2048M

--- a/paq.yaml
+++ b/paq.yaml
@@ -1,2 +1,3 @@
 name: <sample-paq-name>
 memory: 2048M
+cpu: "1"

--- a/paqr/create.py
+++ b/paqr/create.py
@@ -12,9 +12,7 @@ Creates a new paq from the starter-paq template and configures it with the user-
 
 def create_paq(base_dir: str, paq_name: str):
     os.chdir(base_dir)
-    args = ["git", "clone", "https://github.com/qrithm/starter-paq.git"]
-    subprocess.run(args, check=True)
-    args = ["mv", "starter-paq", paq_name]
+    args = ["git", "clone", "https://github.com/qrithm/starter-paq.git", paq_name]
     subprocess.run(args, check=True)
     paq_root = os.path.join(base_dir, paq_name)
     os.chdir(paq_root)

--- a/paqr/create.py
+++ b/paqr/create.py
@@ -1,0 +1,39 @@
+import os
+import argparse
+import subprocess
+import yaml
+import shutil
+
+
+""" 
+Creates a new paq from the starter-paq template and configures it with the user-supplied paq_name
+"""
+
+
+def create_paq(base_dir: str, paq_name: str):
+    os.chdir(base_dir)
+    args = ["git", "clone", "https://github.com/qrithm/starter-paq.git"]
+    subprocess.run(args, check=True)
+    args = ["mv", "starter-paq", paq_name]
+    subprocess.run(args, check=True)
+    paq_root = os.path.join(base_dir, paq_name)
+    os.chdir(paq_root)
+    os.remove("LICENSE")
+    shutil.rmtree(".git")
+    paq_path = "paq.yaml"
+    f = open(paq_path, 'r')
+    paq = yaml.load(f, Loader=yaml.FullLoader)
+    paq['name'] = paq_name
+    f = open(paq_path, 'w')
+    yaml.dump(paq, f)
+    print("Initialized paq {} in base directory {}".format(paq_name, base_dir))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        'base_dir', help="Directory where you want to initialize your paq dir")
+    parser.add_argument(
+        'paq_name', help="Name to be used for your paq")
+    args = parser.parse_args()
+    create_paq(args.base_dir, args.paq_name)

--- a/paqr/docker_utils.py
+++ b/paqr/docker_utils.py
@@ -1,0 +1,33 @@
+import logging
+import subprocess
+
+"""
+Some helper methods for managing Docker containers underlying Paqs.
+
+We may eventually rewrite this using the docker pypi project:
+https://pypi.org/project/docker/
+"""
+
+
+def docker_build(image_name: str, paq_dir: str):
+    args = ["docker", "build", "-t", image_name, paq_dir]
+    logging.info("Building container {}".format(image_name))
+    subprocess.call(args)
+
+
+def docker_run(image_name: str, port: str = "8080:8080"):
+    args = ["docker", "run", "-p", port, image_name]
+    subprocess.call(args)
+
+
+def docker_tag(image_name: str, tag: str = "latest") -> str:
+    gcr_id = "gcr.io/qrithm/{}:{}".format(image_name, tag)
+    args = ["docker", "tag", image_name, gcr_id]
+    subprocess.call(args)
+    return gcr_id
+
+
+def docker_push(image_id: str):
+    args = ["docker", "push", image_id]
+    logging.info("Pushing container {}".format(image_id))
+    subprocess.call(args)

--- a/paqr/docker_utils.py
+++ b/paqr/docker_utils.py
@@ -12,22 +12,22 @@ https://pypi.org/project/docker/
 def docker_build(image_name: str, paq_dir: str):
     args = ["docker", "build", "-t", image_name, paq_dir]
     logging.info("Building container {}".format(image_name))
-    subprocess.call(args)
+    subprocess.run(args, check=True)
 
 
 def docker_run(image_name: str, port: str = "8080:8080"):
     args = ["docker", "run", "-p", port, image_name]
-    subprocess.call(args)
+    subprocess.run(args, check=True)
 
 
 def docker_tag(image_name: str, tag: str = "latest") -> str:
     gcr_id = "gcr.io/qrithm/{}:{}".format(image_name, tag)
     args = ["docker", "tag", image_name, gcr_id]
-    subprocess.call(args)
+    subprocess.run(args, check=True)
     return gcr_id
 
 
 def docker_push(image_id: str):
     args = ["docker", "push", image_id]
     logging.info("Pushing container {}".format(image_id))
-    subprocess.call(args)
+    subprocess.run(args, check=True)

--- a/paqr/gcloud_utils.py
+++ b/paqr/gcloud_utils.py
@@ -13,4 +13,4 @@ def gcloud_deploy(container_id: str, config: dict, allow_unauthenticated: bool =
     if allow_unauthenticated:
         args.append("--allow-unauthenticated")
     logging.info("Deploying container {} to Cloud Run".format(container_id))
-    subprocess.call(args)
+    subprocess.run(args, check=True)

--- a/paqr/gcloud_utils.py
+++ b/paqr/gcloud_utils.py
@@ -1,0 +1,16 @@
+import subprocess
+import logging
+
+"""
+Utils to assist with deploying Paqs to gcloud
+
+"""
+
+
+def gcloud_deploy(container_id: str, config: dict, allow_unauthenticated: bool = True, region: str = "us-east1"):
+    args = ["gcloud", "run", "deploy", config["name"], "--image",
+            container_id, "--platform", "managed", "--memory", config['memory'], "--region", region]
+    if allow_unauthenticated:
+        args.append("--allow-unauthenticated")
+    logging.info("Deploying container {} to Cloud Run".format(container_id))
+    subprocess.call(args)

--- a/paqr/gcloud_utils.py
+++ b/paqr/gcloud_utils.py
@@ -11,6 +11,9 @@ def gcloud_deploy(container_id: str, config: dict, allow_unauthenticated: bool =
     print("Deploying to gcloud with config", config)
     args = ["gcloud", "run", "deploy", config["name"], "--image",
             container_id, "--platform", "managed", "--memory", config['memory'], "--region", region, "--cpu", str(config['cpu'])]
+    if "concurrency" in config.keys():
+        args.append("--concurrency")
+        args.append(config["concurrency"])
     if allow_unauthenticated:
         args.append("--allow-unauthenticated")
     logging.info("Deploying container {} to Cloud Run".format(container_id))

--- a/paqr/gcloud_utils.py
+++ b/paqr/gcloud_utils.py
@@ -8,8 +8,9 @@ Utils to assist with deploying Paqs to gcloud
 
 
 def gcloud_deploy(container_id: str, config: dict, allow_unauthenticated: bool = True, region: str = "us-east1"):
+    print("Deploying to gcloud with config", config)
     args = ["gcloud", "run", "deploy", config["name"], "--image",
-            container_id, "--platform", "managed", "--memory", config['memory'], "--region", region]
+            container_id, "--platform", "managed", "--memory", config['memory'], "--region", region, "--cpu", str(config['cpu'])]
     if allow_unauthenticated:
         args.append("--allow-unauthenticated")
     logging.info("Deploying container {} to Cloud Run".format(container_id))

--- a/paqr/paq.py
+++ b/paqr/paq.py
@@ -1,0 +1,36 @@
+from paqr import qpr
+import os
+import yaml
+
+
+class InvalidPaq(Exception):
+    "Raise this error if paq is invalid"
+    pass
+
+
+def paq_memory_is_valid(memory: str) -> bool:
+    """ TODO: validate the memory specified in paq.yaml is valid """
+    return True
+
+
+def validate_paq(paq_dir: str) -> dict:
+    """ Checks that the paq at paq_dir is valid. Raises InvalidPaq Exception if not. """
+    config_path = os.path.join(paq_dir, 'paq.yaml')
+    if not os.path.isfile(config_path):
+        raise InvalidPaq(
+            "Paq directories must contain a paq.yaml file to be valid")
+    f = open(config_path, 'r')
+    config = yaml.load(f, Loader=yaml.FullLoader)
+    if 'name' not in config.keys():
+        raise InvalidPaq("The paq file must contain a name field")
+    if 'memory' not in config.keys():
+        logging.warn(
+            "The key 'memory' should be specified in your paq.yaml file. Using default value of 2048M for now. You should change this!")
+        config['memory'] = '2048M'
+    if qpr.name_is_available(config['name']) is not True:
+        raise InvalidPaq(
+            "The name {} is already in use. Please select a new name".format(paq_name))
+    if paq_memory_is_valid(config['memory']) is not True:
+        raise InvalidPaq(
+            "The memory specified: {} is not valid. Please use a valid memory")
+    return config

--- a/paqr/paq.py
+++ b/paqr/paq.py
@@ -13,6 +13,11 @@ def paq_memory_is_valid(memory: str) -> bool:
     return True
 
 
+def paq_cpu_is_valid(cpu: str) -> bool:
+    """ TODO: validate the cpu count specified in paq.yaml is valid """
+    return True
+
+
 def validate_paq(paq_dir: str) -> dict:
     """ Checks that the paq at paq_dir is valid. Raises InvalidPaq Exception if not. """
     config_path = os.path.join(paq_dir, 'paq.yaml')
@@ -27,10 +32,17 @@ def validate_paq(paq_dir: str) -> dict:
         logging.warn(
             "The key 'memory' should be specified in your paq.yaml file. Using default value of 2048M for now. You should change this!")
         config['memory'] = '2048M'
+    if 'cpu' not in config.keys():
+        logging.warn(
+            "The key 'cpu' should be specified in your paq.yaml file. Using default value of 1. You should change this!")
+        config['cpu'] = '1'
     if qpr.name_is_available(config['name']) is not True:
         raise InvalidPaq(
             "The name {} is already in use. Please select a new name".format(paq_name))
     if paq_memory_is_valid(config['memory']) is not True:
         raise InvalidPaq(
-            "The memory specified: {} is not valid. Please use a valid memory")
+            "The memory specified: {} is not valid. Please use a valid memory".format(config['memory']))
+    if paq_cpu_is_valid(config['cpu']) is not True:
+        raise InvalidPaq(
+            "The cpu count specified: {} is not valid. Please use a valid memory".format(config['cpu']))
     return config

--- a/paqr/publish.py
+++ b/paqr/publish.py
@@ -1,0 +1,22 @@
+from paqr.paq import validate_paq
+from paqr.docker_utils import *
+from paqr.gcloud_utils import *
+import argparse
+from paqr import qpr
+
+
+def main(args):
+    config = validate_paq(args.paq_dir)
+    docker_build(config['name'], args.paq_dir)
+    gcr_id = docker_tag(config['name'])
+    docker_push(gcr_id)
+    gcloud_deploy(gcr_id, config)
+    qpr.publish(config)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        'paq_dir', help="Path to the base of the paq. Directory must contain a paq.yml file")
+    args = parser.parse_args()
+    main(args)

--- a/paqr/qpr.py
+++ b/paqr/qpr.py
@@ -1,0 +1,17 @@
+
+""" 
+A package to assist with working with the Qrithm Predictor Registry
+"""
+
+
+def publish(config: dict):
+    "TODO: Publish this paq to the qrithm predictor registry"
+    pass
+
+
+def name_is_available(name: str) -> bool:
+    """
+    In the future this will check the name against our predictor registry
+    to verify the name is unique and valid. For now, we just return true
+    """
+    return True

--- a/paqr/run.py
+++ b/paqr/run.py
@@ -1,0 +1,28 @@
+from paqr.paq import validate_paq
+from paqr.docker_utils import *
+import argparse
+
+
+"""
+Builds and runs the paq container on the specified port
+"""
+
+
+def main(args):
+    config = validate_paq(args.paq_dir)
+    if not args.skip_build:
+        docker_build(config['name'], args.paq_dir)
+    docker_run(config['name'], port=args.port)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        'paq_dir', help="Path to the base of the paq. Directory must contain a paq.yml file")
+    parser.add_argument(
+        '--port', help="Port to run the container on", default="8080:8080")
+    parser.add_argument(
+        '--skip_build', help="""Will skip the docker build step and just try and run the container. 
+        This will fail if the container has not been built before or if it is already running on the same port""", action='store_true')
+    args = parser.parse_args()
+    main(args)

--- a/paqr/run.py
+++ b/paqr/run.py
@@ -12,7 +12,7 @@ def main(args):
     config = validate_paq(args.paq_dir)
     if not args.skip_build:
         docker_build(config['name'], args.paq_dir)
-    docker_run(config['name'], port=args.port)
+    docker_run(config['name'], port=args.p)
 
 
 if __name__ == '__main__':
@@ -20,7 +20,7 @@ if __name__ == '__main__':
     parser.add_argument(
         'paq_dir', help="Path to the base of the paq. Directory must contain a paq.yml file")
     parser.add_argument(
-        '--port', help="The port mapping from docker container to host", default="8080:8080")
+        '--p', help="The port mapping from docker container to host", default="8080:8080")
     parser.add_argument(
         '--skip_build', help="""Will skip the docker build step and just try and run the container. 
         This will fail if the container has not been built before or if it is already running on the same port""", action='store_true')

--- a/paqr/run.py
+++ b/paqr/run.py
@@ -20,7 +20,7 @@ if __name__ == '__main__':
     parser.add_argument(
         'paq_dir', help="Path to the base of the paq. Directory must contain a paq.yml file")
     parser.add_argument(
-        '--port', help="Port to run the container on", default="8080:8080")
+        '--port', help="The port mapping from docker container to host", default="8080:8080")
     parser.add_argument(
         '--skip_build', help="""Will skip the docker build step and just try and run the container. 
         This will fail if the container has not been built before or if it is already running on the same port""", action='store_true')

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 
 # Package Metadata
 NAME = 'paqr'
-VERSION = '0.0.1'
+VERSION = '0.0.2'
 
 
 def required_packages():

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ def required_packages():
         'fastapi == 0.60.1',
         'python-multipart == 0.0.5',
         'requests == 2.24.0',
+        'PyYAML == 5.3.1'
     ]
     return PACKAGES
 


### PR DESCRIPTION
Adds some lightweight helper methods for publishing predictors. I tested this out both /template and /esrgan -- I will push updates to those that include a paq.yaml file.

At the moment this is more-or-less still an internal tool. Before we market this we will want to do some things like:

* Implement the methods for working with the qpr
* Expose endpoints our own API endpoints for publishing containers, rather than pushing direction to gcr from these scripts, which definitely won't work if people don't have credentials.

For now though, this should speed things up and can evolve into something more powerful like cloud build+publish from a github repo